### PR TITLE
Implement category API: get all category

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,16 @@ This is a online academy, Back-end is Nodejs, Front-End is ReactJs
   ```code
   localhost:8080/search?keyword=react
   ```
+
+###  Category API
+#### Get all categories
+
+- Method: `GET /categories`
+- Status Code:
+  - Success: `200`
+  - Failure: `400`
+- Sample:
+
+  ```code
+  http://localhost:8080/categories
+  ```

--- a/app.js
+++ b/app.js
@@ -15,12 +15,14 @@ app.use(express.json());
 app.use(morgan("dev"));
 
 // define routing
-const guestRouter = require("./routes/guest.route");
+// const guestRouter = require("./routes/guest.route");
 const userRouter = require("./routes/user.route");
 const authRouter = require("./routes/auth.route");
+const categoryRouter = require("./routes/category.route");
+
 app.use("/auth", authRouter);
 app.use("/:userId", userRouter);
-app.use(guestRouter);
+app.use("/categories", categoryRouter);
 
 // define error route handler
 app.use((req, res, next) => {

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -1,0 +1,18 @@
+"use strict";
+const categoryService = require("../services/category.service");
+const Config = require("../configs/constrainst");
+
+module.exports = {
+  getAllCategory: async (req, res) => {
+    const result = {};
+    try {
+      const categories = await categoryService.getAll();
+
+      result.web = categories.filter((category) => category.level === Config.CATEGORY_LEVEL.WEB);
+      result.mobile = categories.filter((category) => category.level === Config.CATEGORY_LEVEL.MOBILE);
+    } catch (error) {
+      throw new Error(error);
+    }
+    res.json(result);
+  }
+};

--- a/routes/category.route.js
+++ b/routes/category.route.js
@@ -1,0 +1,11 @@
+"use strict";
+const express = require("express");
+// eslint-disable-next-line new-cap
+const router = express.Router();
+
+const categoryController = require("../controllers/category.controller");
+
+router.get("/", categoryController.getAllCategory);
+
+
+module.exports = router;

--- a/routes/user.route.js
+++ b/routes/user.route.js
@@ -6,11 +6,11 @@ const router = express.Router();
 const UserController = require("../controllers/user.controller");
 const Validator = require("../middlewares/validator.mdw");
 
-router.get("/", (req, res, next) => {
-  res.json({
-    message: "tested"
-  });
-});
+// router.get("/", (req, res, next) => {
+//   res.json({
+//     message: "tested"
+//   });
+// });
 
 router.post("/", Validator.validateRequestBody("register_student"), UserController.createNewStudent);
 

--- a/services/category.service.js
+++ b/services/category.service.js
@@ -1,0 +1,12 @@
+"use strict";
+const categoryModel = require("../models/category.model");
+
+module.exports = {
+  /**
+   *
+   * @return {Array} list category
+   */
+  getAll: async () => {
+    return await categoryModel.find({});
+  }
+};


### PR DESCRIPTION
Khi tham chiếu từ collection course tới category thông qua thuộc tính "ref"

`  category: {
    type: mongoose.Types.ObjectId,
    ref: Config.COLLECTION_NAME.CATEGORY,
    require: true
  }`

nó yêu cầu phải khai báo cái Category model trước nên ae để ý chỗ này nghe :+1: 